### PR TITLE
change toArray behavior

### DIFF
--- a/src/ReadWriteAttributes.php
+++ b/src/ReadWriteAttributes.php
@@ -26,7 +26,7 @@ trait ReadWriteAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         $this->attributes->set($propertyName, $value);

--- a/src/ReadableAttributes.php
+++ b/src/ReadableAttributes.php
@@ -192,10 +192,13 @@ trait ReadableAttributes
     public function toArray()
     {
         $array = [];
-        foreach (array_keys($this->attributes->getRaw()) as $keyName) {
-            $getterFuncName = 'get' . str_replace(' ', '', ucwords(str_replace('_', ' ', $keyName)));
-            if (is_callable([$this, $getterFuncName])) {
-                $array[$keyName] = call_user_func([$this, $getterFuncName]);
+        $klass = new \ReflectionClass(__CLASS__);
+        /* @var \ReflectionMethod $method */
+        foreach ($klass->getMethods() as $method) {
+            $methodName = $method->getName();
+            if (strpos($methodName, 'get') === 0) {
+                $keyName = str_replace(' ', '', ucwords(str_replace('_', ' ', $methodName)));
+                $array[$keyName] = call_user_func([$this, $methodName]);
             }
         }
 

--- a/src/ReadableAttributes.php
+++ b/src/ReadableAttributes.php
@@ -13,7 +13,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asInteger($validate);
@@ -23,7 +23,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asString($validate);
@@ -33,7 +33,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asFloat($validate);
@@ -43,7 +43,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asBoolean($validate);
@@ -53,7 +53,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asArray($validate);
@@ -63,7 +63,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asIntegerArray();
@@ -73,7 +73,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asStringArray();
@@ -83,7 +83,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asFloatArray();
@@ -93,7 +93,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mustHave($propertyName)->asBooleanArray();
@@ -103,7 +103,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asInteger($validate);
@@ -113,7 +113,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asString($validate);
@@ -123,7 +123,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asFloat($validate);
@@ -133,7 +133,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asBoolean($validate);
@@ -143,7 +143,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asArray($validate);
@@ -153,7 +153,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asIntegerArray();
@@ -163,7 +163,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asStringArray();
@@ -173,7 +173,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asFloatArray();
@@ -183,7 +183,7 @@ trait ReadableAttributes
     {
         static $propertyName;
         if ($propertyName === null) {
-            $propertyName = $this->getCalledPropertyName();
+            $propertyName = $this->calledPropertyName();
         }
 
         return $this->attributes->mayHave($propertyName)->asBooleanArray();
@@ -196,8 +196,8 @@ trait ReadableAttributes
         /* @var \ReflectionMethod $method */
         foreach ($klass->getMethods() as $method) {
             $methodName = $method->getName();
-            if (strpos($methodName, 'get') === 0) {
-                $keyName = str_replace(' ', '', ucwords(str_replace('_', ' ', $methodName)));
+            if (strpos($methodName, 'get') === 0 && $methodName !== 'get' && $methodName !== 'getRaw') {
+                $keyName = $this->methodNameToPropertyName($methodName);
                 $array[$keyName] = call_user_func([$this, $methodName]);
             }
         }
@@ -208,7 +208,7 @@ trait ReadableAttributes
     /*
      * @return string
      */
-    public function getCalledPropertyName()
+    public function calledPropertyName()
     {
         $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1]['function'];
 
@@ -217,5 +217,18 @@ trait ReadableAttributes
             '_$0',
             lcfirst(preg_replace('/^(get|set)/', '', $backtrace))
         ));
+    }
+
+    public function methodNameToPropertyName($getterName)
+    {
+        $underscored = strtolower(
+            preg_replace(
+                ["/^get/", "/([A-Z]+)/", ],
+                ["", "_$1"],
+                $getterName
+            )
+        );
+
+        return substr($underscored, 1, strlen($underscored));
     }
 }

--- a/tests/Example/ObjectUsingUtility.php
+++ b/tests/Example/ObjectUsingUtility.php
@@ -17,9 +17,9 @@ class ObjectUsingUtility
         return $this->attributes->mayHave('created')->asInstanceOf('\\Datetime');
     }
 
-    public function getCreatedDatetimeOrThrow()
+    public function getCreatedDatetime()
     {
-        return $this->attributes->mustHave('created')->asInstanceOf('\\Datetime');
+        return $this->attributes->mustHave('created_datetime')->asInstanceOf('\\Datetime');
     }
 
     public function getUpdatedHistories()
@@ -27,9 +27,9 @@ class ObjectUsingUtility
         return $this->attributes->mayHave('updated_histories')->asInstanceArray('\\Datetime');
     }
 
-    public function getUpdatedHistoriesOrThrow()
+    public function getUpdatedHistoriesDatetime()
     {
-        return $this->attributes->mustHave('updated_histories')->asInstanceArray('\\Datetime');
+        return $this->attributes->mustHave('updated_histories_datetime')->asInstanceArray('\\Datetime');
     }
 
     public function getRaw()

--- a/tests/RequiredThrowsTest.php
+++ b/tests/RequiredThrowsTest.php
@@ -9,6 +9,15 @@ class RequiredThrowsTest extends \PHPUnit_Framework_TestCase
     /**
      * @expectedException \TurmericSpice\Container\InvalidAttributeException
      */
+    public function testToArrayThrowsWithUndefined()
+    {
+        $required = new ObjectWithRequiredValues([]);
+        $required->toArray();
+    }
+
+    /**
+     * @expectedException \TurmericSpice\Container\InvalidAttributeException
+     */
     public function testGetOneThrowsWithUndefined()
     {
         $required = new ObjectWithRequiredValues([]);

--- a/tests/UtilityTest.php
+++ b/tests/UtilityTest.php
@@ -12,11 +12,17 @@ class UtilityTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->object_using_utility = new ObjectUsingUtility([
-            'created' => '2015-01-01 00:00:00',
+            'created'           => '2015-01-01 00:00:00',
+            'created_datetime'  => new \DateTime('2015-01-01 00:00:00'),
             'updated_histories' => [
                 '2016-01-01 00:00:00',
                 '2017-01-01 00:00:00',
                 '2018-01-01 00:00:00',
+            ],
+            'updated_histories_datetime' => [
+                new \Datetime('2016-01-01 00:00:00'),
+                new \Datetime('2017-01-01 00:00:00'),
+                new \Datetime('2018-01-01 00:00:00'),
             ]
         ]);
     }
@@ -33,8 +39,11 @@ class UtilityTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetCreatedThrows()
     {
-        // raw created is only string. so exception occurs.
-        $this->object_using_utility->getCreatedDatetimeOrThrow();
+        // raw created is string. so exception occurs.
+        $object_using_utility = new ObjectUsingUtility([
+            'created_datetime' => '2015-01-01 00:00:00',
+        ]);
+        $object_using_utility->getCreatedDatetime();
     }
 
     /**
@@ -42,28 +51,47 @@ class UtilityTest extends \PHPUnit_Framework_TestCase
      */
     public function testUpdatedHistoriesThrows()
     {
-        $this->object_using_utility->getUpdatedHistoriesOrThrow();
+        $object_using_utility = new ObjectUsingUtility([
+            'updated_histories_datetime' => [
+                '2016-01-01 00:00:00',
+                '2017-01-01 00:00:00',
+                '2018-01-01 00:00:00',
+            ]
+        ]);
+        $object_using_utility->getUpdatedHistoriesDatetime();
     }
 
     public function testGetRaw()
     {
         $expected = [
-            'created' => '2015-01-01 00:00:00',
+            'created'           => '2015-01-01 00:00:00',
+            'created_datetime'  => new \DateTime('2015-01-01 00:00:00'),
             'updated_histories' => [
                 '2016-01-01 00:00:00',
                 '2017-01-01 00:00:00',
                 '2018-01-01 00:00:00',
+            ],
+            'updated_histories_datetime' => [
+                new \Datetime('2016-01-01 00:00:00'),
+                new \Datetime('2017-01-01 00:00:00'),
+                new \Datetime('2018-01-01 00:00:00'),
             ]
         ];
 
-        $this->assertSame($expected, $this->object_using_utility->getRaw());
+        $this->assertEquals($expected, $this->object_using_utility->getRaw());
     }
 
     public function testToArray()
     {
         $expected = [
-            'created' => new \DateTime('2015-01-01 00:00:00'),
+            'created'           => new \DateTime('2015-01-01 00:00:00'),
+            'created_datetime'  => new \DateTime('2015-01-01 00:00:00'),
             'updated_histories' => [
+                new \Datetime('2016-01-01 00:00:00'),
+                new \Datetime('2017-01-01 00:00:00'),
+                new \Datetime('2018-01-01 00:00:00'),
+            ],
+            'updated_histories_datetime' => [
                 new \Datetime('2016-01-01 00:00:00'),
                 new \Datetime('2017-01-01 00:00:00'),
                 new \Datetime('2018-01-01 00:00:00'),


### PR DESCRIPTION
toArray について、現在保持している配列のキーから getXXX という文字列を作って callable だったら呼ぶという実装だったが、保持している getXXX 関数を全て呼ぶという挙動にした。

配列をキーから getter メソッドの文字列を生成するとキーが未定義だった場合 toArray にそのキーが入ってこないのでオェクトの型の保証が弱くなってしまう。

``` php
class User
{
    ReadableAttributes {
        mustHaveAsId as getId
    }
}

$user = new User([]);
$user->toArray(); // 現状だと id は mustHave なのにそもそもキーが渡されていないので例外が出ない
```

保持している関数名から toArray したほうがオブジェクトの定義に忠実にはなる。
注意点として、メソッド名から array を作るため、渡されたプロパティ名と getter が違う名前だと変わった挙動をしてしまう

``` php
class User
{
    ReadableAttributes {
        mayHaveAsString as getNameXXX
    }
}

$user = new User(['name' => 'test']);
$user->toArray(); // ['name_xxx' => 'test'] が返ってくる
```

どっちの挙動を取るかという話だが、オブジェクトの定義に忠実な方が実用的なのでそっちをとりたい。

そもそも turmeric-spice に付属している toArray に過度な期待はしてはいけない。
