### PR TITLE
enable asXXXArray to be passed validator

### DIFF
--- a/src/Container/ValueAbstract.php
+++ b/src/Container/ValueAbstract.php
@@ -51,53 +51,58 @@ abstract class ValueAbstract
     abstract public function asInstanceOf($className, callable $validate = null);
 
     /**
-     * @return string[]
+     * @param callable $validate
+     * @return \string[]
      */
-    public function asStringArray()
+    public function asStringArray(callable $validate = null)
     {
-        return $this->castRecursively($this->asArray(), 'asString');
+        return $this->castArray($this->asArray(), 'asString', [$validate]);
     }
 
     /**
-     * @return int[]
+     * @param callable $validate
+     * @return \int[]
      */
-    public function asIntegerArray()
+    public function asIntegerArray(callable $validate = null)
     {
-        return $this->castRecursively($this->asArray(), 'asInteger');
+        return $this->castArray($this->asArray(), 'asInteger', [$validate]);
     }
 
     /**
-     * @return float[]
+     * @param callable $validate
+     * @return \float[]
      */
-    public function asFloatArray()
+    public function asFloatArray(callable $validate = null)
     {
-        return $this->castRecursively($this->asArray(), 'asFloat');
+        return $this->castArray($this->asArray(), 'asFloat', [$validate]);
     }
 
     /**
-     * @return bool[]
+     * @param callable $validate
+     * @return \bool[]
      */
-    public function asBooleanArray()
+    public function asBooleanArray(callable $validate = null)
     {
-        return $this->castRecursively($this->asArray(), 'asBoolean');
+        return $this->castArray($this->asArray(), 'asBoolean', [$validate]);
     }
 
     /**
      * @param $className
-     * @return mixed[]
+     * @param callable $validate
+     * @return \mixed[]
      */
-    public function asInstanceArray($className)
+    public function asInstanceArray($className, callable $validate = null)
     {
-        return $this->castRecursively($this->asArray(), 'asInstanceOf', [$className]);
+        return $this->castArray($this->asArray(), 'asInstanceOf', [$className, $validate]);
     }
 
-    private function castRecursively($arr, $castedType, $arg = [])
+    private function castArray($rawArray, $castedType, $arg = [])
     {
-        return array_map(function ($val) use ($castedType, $arg) {
-            if (is_array($val)) {
-                return $this->castRecursively($val, $castedType, $arg);
-            }
-            return call_user_func_array([(new static($this->key, $val)), $castedType], $arg);
-        }, $arr);
+        $castedArray = [];
+        foreach ($rawArray as $rawValue) {
+            $castedArray[] = call_user_func_array([(new static($this->key, $rawValue)), $castedType], $arg);
+        }
+
+        return $castedArray;
     }
 }

--- a/tests/Example/ObjectWithValidation.php
+++ b/tests/Example/ObjectWithValidation.php
@@ -101,4 +101,11 @@ class ObjectWithValidation
             return $value === new \DateTime('2014-01-01 00:00:00');
         });
     }
+
+    public function getDateTime2014ArrayOrThrow()
+    {
+        return $this->attributes->mustHave('datetime_arr')->asInstanceArray('\\Datetime', function ($value) {
+            return $value === new \DateTime('2014-01-01 00:00:00');
+        });
+    }
 }

--- a/tests/ValidationTest.php
+++ b/tests/ValidationTest.php
@@ -18,6 +18,7 @@ class ValidationTest extends \PHPUnit_Framework_TestCase
             'fruits_names' => ['red', 'green', 'yellow'],
             'flag'         => 'true',
             'datetime'     => new \DateTime('2015-01-01 00:00:00'),
+            'datetime_arr' => [new \DateTime('2015-01-01 00:00:00')],
         ]);
     }
 
@@ -97,5 +98,13 @@ class ValidationTest extends \PHPUnit_Framework_TestCase
     public function testGetDateTimeThrow()
     {
         $this->objectWithValidation->getDateTime2014OrThrow();
+    }
+
+    /**
+     * @expectedException \TurmericSpice\Container\InvalidAttributeException
+     */
+    public function testGetDateTimeArrayThrow()
+    {
+        $this->objectWithValidation->getDateTime2014ArrayOrThrow();
     }
 }


### PR DESCRIPTION
`asXXXArray` 系の関数に validator を渡せるようにした。
厳密には `asXXXArray` の前の asArray にも validator 渡せたほうがいいのかもしれないが今のところ需要もないしごちゃごちゃしそうなのでやっていない。

また、再帰でキャストするのは期待値と違う気がするので止めた
