### PR TITLE
Revert less instantiate

### DIFF
--- a/src/Container.php
+++ b/src/Container.php
@@ -12,27 +12,19 @@ class Container
      * @var array
      */
     private $attributes;
-    private $optionalValue;
-    private $requiredValue;
 
     public function __construct(array $attributes)
     {
         $this->attributes = $attributes;
-        $this->optionalValue = new OptionalValue();
-        $this->requiredValue = new RequiredValue();
     }
 
     public function mayHave($key)
     {
-        $this->optionalValue->key = $key;
         if (! isset($this->attributes[$key])) {
-            $this->optionalValue->value = null;
-
-            return $this->optionalValue;
+            return new OptionalValue($key, null);
         }
-        $this->optionalValue->value = $this->attributes[$key];
 
-        return $this->optionalValue;
+        return new OptionalValue($key, $this->attributes[$key]);
     }
 
     public function mustHave($key)
@@ -40,10 +32,8 @@ class Container
         if (! isset($this->attributes[$key])) {
             throw new InvalidAttributeException("$key is not set.");
         }
-        $this->requiredValue->key = $key;
-        $this->requiredValue->value = $this->attributes[$key];
 
-        return $this->requiredValue;
+        return new RequiredValue($key, $this->attributes[$key]);
     }
 
     public function set($key, $value)

--- a/src/Container/ValueAbstract.php
+++ b/src/Container/ValueAbstract.php
@@ -4,8 +4,14 @@ namespace TurmericSpice\Container;
 
 abstract class ValueAbstract
 {
-    public $key;
-    public $value;
+    protected $key;
+    protected $value;
+
+    public function __construct($key, $value)
+    {
+        $this->key = $key;
+        $this->value = $value;
+    }
 
     /**
      * @param callable|null $validate
@@ -94,11 +100,7 @@ abstract class ValueAbstract
     {
         $castedArray = [];
         foreach ($rawArray as $rawValue) {
-            $valueObject = new static();
-            $valueObject->key = $this->key;
-            $valueObject->value = $rawValue;
-
-            $castedArray[] = call_user_func_array([$valueObject, $castedType], $arg);
+            $castedArray[] = call_user_func_array([(new static($this->key, $rawValue)), $castedType], $arg);
         }
 
         return $castedArray;


### PR DESCRIPTION
`TurmericSpice\Container` の `mayHave()` が異なるキー名で2回以上連続で呼ばれた場合、
`$this->optionalValue` が同じオブジェクトを参照してるために最初の値が後の値で上書きされてしまうのでとりあえず元に戻します

This reverts commit ec06573689d8685c8a281c241da7c33901807f79, reversing
changes made to 9fa1d27508becc4a4e82a42016c9708ed8af8560.
