### PR TITLE
revert prop

### DIFF
--- a/src/ReadableAttributes.php
+++ b/src/ReadableAttributes.php
@@ -2,11 +2,11 @@
 
 namespace TurmericSpice;
 
+/**
+ * @property Container $attributes
+ */
 trait ReadableAttributes
 {
-    /** @var Container */
-    protected $attributes;
-
     public function __construct(array $attributes = [])
     {
         $this->attributes = new Container($attributes);


### PR DESCRIPTION
https://travis-ci.org/gong023/shippo-http-client/jobs/215656041

```
1) ShippoClient\Http\Request\Rates\ValidRequestTest::getListOfRateByShipment
ShippoClient\Entity\ObjectInformation and TurmericSpice\ReadableAttributes define the same property ($attributes) in the composition of ShippoClient\Entity\Rate. This might be incompatible, to improve maintainability consider using accessor methods in traits instead. Class was composed
```

これがダルいんで一旦revertする
phan がおせっかいしてくる件はまた今度考える