### PR TITLE
PHP 8.2 Dynamic Property Fix: ReadableAttributes::$attributes

### DIFF
--- a/src/ReadableAttributes.php
+++ b/src/ReadableAttributes.php
@@ -2,11 +2,11 @@
 
 namespace TurmericSpice;
 
-/**
- * @property Container $attributes
- */
 trait ReadableAttributes
 {
+    /** @var Container $attributes */
+    protected $attributes;
+
     public function __construct(array $attributes = [])
     {
         $this->attributes = new Container($attributes);


### PR DESCRIPTION
* Dynamic property deprecation fix for PHP 8.2
```
Deprecated: Creation of dynamic property 
SomeClass::$attributes is deprecated in /.../vendor/gong023/turmeric-spice/src/ReadableAttributes.php on line 12
```